### PR TITLE
chore: add separate dev requirements file (#2)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+-r requirements.txt
+
+# Development dependencies
+pytest
+black
+flake8
+isort
+pre-commit


### PR DESCRIPTION
Added a requirements-dev.txt to separate development dependencies.
Moved tools like pytest, black, flake8, etc. out of the main requirements.
Referenced requirements.txt inside it to avoid duplication.

Closes #2